### PR TITLE
Support the new lsp/ directory in Neovim 0.11+

### DIFF
--- a/lua/auto-lsp/generate.lua
+++ b/lua/auto-lsp/generate.lua
@@ -25,7 +25,11 @@ local function generate(config_dir)
   for _, file in ipairs(config_files) do
     local name = vim.fn.fnamemodify(file, ":r")
     local path = vim.fs.joinpath(config_dir, file)
-    local config = dofile(path).default_config
+    local config = dofile(path)
+    -- keeps backward compatibility with the legacy nvim-lspconfig scheme
+    if config.default_config then
+      config = config.default_config
+    end
 
     if config.filetypes then
       for _, ft in ipairs(config.filetypes) do

--- a/lua/auto-lsp/generate.lua
+++ b/lua/auto-lsp/generate.lua
@@ -1,5 +1,4 @@
-local vim = vim
-local uv = vim.uv
+local uv = vim.uv or vim.loop
 
 -- filter out language / package manager commands e.g. python -m <module>
 local ignored_executables = {
@@ -24,7 +23,7 @@ local function generate(config_dir)
   local config_files = vim.fn.readdir(config_dir)
   for _, file in ipairs(config_files) do
     local name = vim.fn.fnamemodify(file, ":r")
-    local path = vim.fs.joinpath(config_dir, file)
+    local path = config_dir .. file
     local config = dofile(path)
     -- keeps backward compatibility with the legacy nvim-lspconfig scheme
     if config.default_config then

--- a/lua/auto-lsp/handler.lua
+++ b/lua/auto-lsp/handler.lua
@@ -72,7 +72,12 @@ function M:check_server(name, recheck)
     end
 
     config = vim.tbl_deep_extend("force", self.global_config, config)
-    require("lspconfig")[name].setup(config)
+    if vim.lsp.config then
+      vim.lsp.config(name, config)
+      vim.lsp.enable(name)
+    else
+      require("lspconfig")[name].setup(config)
+    end
   end
 
   self.checked_servers[name] = config and true or false

--- a/lua/auto-lsp/handler.lua
+++ b/lua/auto-lsp/handler.lua
@@ -1,5 +1,3 @@
-local vim = vim
-
 local augroup = vim.api.nvim_create_augroup
 local doautocmd = vim.api.nvim_exec_autocmds
 

--- a/lua/auto-lsp/init.lua
+++ b/lua/auto-lsp/init.lua
@@ -39,8 +39,8 @@ function M.setup(opts)
     mappings = M.build()
   end
 
-  local global_config = opts["*"] or {}
-  local server_config = opts
+  local server_config = opts or {}
+  local global_config = server_config["*"] or {}
   server_config["*"] = nil
 
   opts = vim.tbl_extend("error", mappings, {

--- a/lua/auto-lsp/init.lua
+++ b/lua/auto-lsp/init.lua
@@ -8,8 +8,9 @@ local autocmd = vim.api.nvim_create_autocmd
 
 M.MAPPINGS_FILE = vim.fn.stdpath("data") .. "/auto-lsp-mappings.lua"
 M.LSPCONFIG_DIR = assert(
+  vim.api.nvim_get_runtime_file("lsp/", false)[1] or
   vim.api.nvim_get_runtime_file("lua/lspconfig/configs/", false)[1],
-  "Could not find `lua/lspconfig/` directory in the 'runtimepath'"
+  "Could not find `lsp/` or `lua/lspconfig/configs/` directory in the 'runtimepath'"
 )
 
 function M.build()


### PR DESCRIPTION
The `lua/lspconfig/configs/` module has been deprecated on `nvim-lspconfig` master branch, and will be removed later. So this patch adds support for the new `vim.lsp.config()` approach introduced in Neovim 0.11+, while still keeps compatibility with the directory structure in older versions.

Edit: Closes #11